### PR TITLE
[김지연] error message 변경

### DIFF
--- a/WebRTC/settings.py
+++ b/WebRTC/settings.py
@@ -18,7 +18,7 @@ SECRET_KEY = SECRET_KEY
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition
@@ -146,3 +146,7 @@ CORS_ALLOW_HEADERS = (
 APPEND_SLASH = False
 
 AUTH_USER_MODEL = 'users.User'
+
+REST_FRAMEWORK = {
+    'NON_FIELD_ERRORS_KEY': 'message',
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-channels            3.0.4
+channels==3.0.4
 Django==4.0.2
 django-cors-headers==3.11.0
 django-extensions==3.1.5
-djangorestframework 3.13.pip
+djangorestframework==3.13.3
 ipython==8.0.1
 mysqlclient==2.1.0
 PyMySQL==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ channels==3.0.4
 Django==4.0.2
 django-cors-headers==3.11.0
 django-extensions==3.1.5
-djangorestframework==3.13.3
+djangorestframework==3.13.4
 ipython==8.0.1
 mysqlclient==2.1.0
 PyMySQL==1.0.2

--- a/users/serializers.py
+++ b/users/serializers.py
@@ -35,16 +35,13 @@ class UserSignInSerializer(serializers.Serializer):
         email    = data.get('email')
         password = data.get('password')
 
-        if not email or not password:
-            raise serializers.ValidationError({'"email"과 "password"를 입력해주세요.'})
-        
         try:
             user = User.objects.get(email=email)
         except User.DoesNotExist:
-            raise serializers.ValidationError({'사용자 확인이 불가능합니다.'})
+            raise serializers.ValidationError('사용자 확인이 불가능합니다.')
 
         if not user.check_password(password):
-                raise serializers.ValidationError({'사용자 확인이 불가능합니다.'})
+                raise serializers.ValidationError('사용자 확인이 불가능합니다.')
         
         data['user'] = user
         return data

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,4 @@
+from rest_framework import status
 from rest_framework.authtoken.models import Token
 from rest_framework.generics import CreateAPIView
 from rest_framework.response import Response
@@ -11,6 +12,9 @@ class UserSignUpAPIView(CreateAPIView):
 
 class UserSignInAPIView(APIView):
     def post(self, request):
+        if not request.data.get('email') or not request.data.get('password'):
+            return Response({'message':['email과 password를 입력해주세요.']}, status=status.HTTP_400_BAD_REQUEST)
+
         serializer = UserSignInSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)        
         user = serializer.validated_data['user']


### PR DESCRIPTION
## 구현 목표
- 에러 메시지의 `NON_FIELD_ERRORS_KEY` key 변경
- 에러 메시지 형식 변경
- `ALLOWED_HOSTS` 수정
- requirements.txt typos 수정

## 구현 사항 설명
- 회원가입/로그인 통신시 반환하는 에러메시지의 key를 `non_field_errors`에서 `message`로 변경하여 메시지를 명확히 하였습니다.
- `ALLOWED_HOSTS`의 값을 변경하여 `localhost`에서만 접속이 가능한 것을 변경하였습니다.
- error message가 {'message': ['message']} 형식이 되도록 변경하였습니다.

## 특이사항